### PR TITLE
Synced with latest aacotroneo, to get onelogin v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
+
 
 before_script:
   - travis_retry composer self-update

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Alejandro Cotroneo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -11,54 +11,84 @@ The aim of this library is to be as simple as possible. We won't mess with Larav
 
 ## Installation - Composer
 
-To install Saml2 as a Composer package to be used with Laravel 5, simply add this to your composer.json:
+You can install the package via composer:
+
+```
+composer require nirajp/laravel-saml2
+```
+Or manually add this to your composer.json:
 
 ```json
 "nirajp/laravel-saml2": "*"
 ```
 
-..and run `composer update`.  Once it's installed, you can register the service provider in `app/config/app.php` in the `providers` array. If you want, you can add the alias saml2:
+If you are using Laravel 5.5 and up, the service provider will automatically get registered.
+
+For older versions of Laravel (<5.5), you have to add the service provider and alias to config/app.php:
 
 ```php
 'providers' => [
         ...
-    	'Aacotroneo\Saml2\Saml2ServiceProvider',
+    	Aacotroneo\Saml2\Saml2ServiceProvider::class,
 ]
 
 'alias' => [
         ...
-        'Saml2'     => 'Aacotroneo\Saml2\Facades\Saml2Auth',
+        'Saml2' => Aacotroneo\Saml2\Facades\Saml2Auth::class,
 ]
 ```
 
-Then publish the config files with `php artisan vendor:publish`. This will add the files `app/config/saml2_settings.php` & `app/config/saml2/test_idp_settings.php`. 
+Then publish the config files with `php artisan vendor:publish --provider="Aacotroneo\Saml2\Saml2ServiceProvider"`. This will add the files `app/config/saml2_settings.php` & `app/config/saml2/test_idp_settings.php`.
 
 The test_idp_settings.php config is handled almost directly by  [OneLogin](https://github.com/onelogin/php-saml) so you may get further references there, but will cover here what's really necessary. There are some other config about routes you may want to check, they are pretty strightforward.
 
 ### Configuration
 
-Define names of all the IDPs you want to configure in saml2_settings.php. Keep 'test' as the first IDP, and add real IDPs after that.
+#### Define the IDPs
+Define names of all the IDPs you want to configure in saml2_settings.php. Optionally keep 'test' as the first IDP if you want to use the simplesamlphp demo, and add real IDPs after that.
 
 ```php
     'idpNames' => ['test', 'myidp1', 'myidp2'],
 ```
 
-You will need to create a separate configuration file for each IDP under `app/config/saml2` folder. e.g. `myidp1_idp_settings.php`. You can use `test_idp_settings.php` as the starting point.
+#### Configure laravel-saml2 to know about each IDP
 
-The only real difference between this config and the one that OneLogin uses, is that the SP entityId, assertionConsumerService url and singleLogoutService URL are injected by the library. They are taken from routes 'saml_metadata', 'saml_acs' and 'saml_sls' respectively.
+You will need to create a separate configuration file for each IDP under `app/config/saml2/` folder. e.g. `myidp1_idp_settings.php`. You can use `test_idp_settings.php` as the starting point; just copy it to `app/config/saml2/` and rename it.
 
-Remember that you don't need to implement those routes, but you'll need to add them to your IDP configuration. For example, if you use simplesamlphp, add the following to /metadata/sp-remote.php
+Configuration options are note explained in this project as they come from the [OneLogin project](https://github.com/onelogin/php-saml), please refer there for details.
+
+The only real difference between this config and the one that OneLogin uses, is that the SP entityId, assertionConsumerService url and singleLogoutService URL are injected by the library. If you don't specify those URLs in the corresponding IDP config optional values, this library provides defaults values, the routes that this library creates for each IDP, which are given route names "{$idpName}_metadata", "{$idpName}_acs" and "{$idpName}_sls".
+
+If you want to define values in ENV vars instead of the \*\_idp_settings file, you'll see in there that the ENV values follow a naming pattern. For example, if in myipd1_idp_settings.php you set `$this_idp_env_id = 'MYIDP1';`, and in myidp2_idp_settings.php you set it to `'SECONDIDP'`, then you can set ENV vars starting with `SAML2_MYDP1_` and `SAML2_SECONDIDP_`, e.g.
+```env
+SAML2_MYIDP1_SP_x509="..."
+SAML2_MYIDP1_SP_PRIVATEKEY="..."
+// Other  SAML2_MYIDP1_* values
+
+SAML2_SECONDIDP_SP_x509="..."
+SAML2_SECONDIDP_SP_PRIVATEKEY="..."
+// Other SAML2_SECONDIDP_* values
+```
+
+#### URLs To Pass to The IDP configuration
+You don't need to implement the SP entityId, assertionConsumerService url and singleLogoutService routes, because Saml2Controller already does, but you'll need to provide them to the configuration of your actual IDP, i.e. the 3rd party you are asking to authenticate users.
+
+You can check the actual routes in the metadata, by navigating to 'http://laravel_url/myidp1/metadata' / 'https://laravel_url/myidp1/metadata', which incidentally will be the entityId for this SP.
+
+If you configure the optional `routesPrefix` setting in saml2_settings.php, then all idp routes will be prefixed by that value, so you'll need to adjust the metadata url accordingly. For example, if you configure routesPrefix to be `'single_sign_on'`, then your IDP metadata for myidp1 will be found at http://laravel_url/single_sign_on/myidp1/metadata.
+
+#### Exampl: simplesamlphp IDP configuration
+For example, if you use simplesamlphp, and your metadata url is `http://laravel_url/myidp1/metadata`, add the following to /metadata/sp-remote.php to inform the IDP of your laravel-saml2 SP identity:
 
 ```php
-$metadata['http://laravel_url/saml/metadata'] = array(
-    'AssertionConsumerService' => 'http://laravel_url/saml/acs',
-    'SingleLogoutService' => 'http://laravel_url/saml/sls',
+$metadata['http://laravel_url/myidp1/metadata'] = array(
+    'AssertionConsumerService' => 'http://laravel_url/myidp1/acs',
+    'SingleLogoutService' => 'http://laravel_url/myidp1/sls',
     //the following two affect what the $Saml2user->getUserId() will return
     'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
     'simplesaml.nameidattribute' => 'uid' 
 );
 ```
-You can check that metadata if you actually navigate to 'http://laravel_url/saml/metadata'
 
 
 ### Usage
@@ -81,14 +111,29 @@ When you want your user to login, just call `Saml2Auth::login()` or redirect to 
 		}
 
 		return $next($request);
-	};
+	}
 ```
 
-The Saml2::login will redirect the user to the IDP and will came back to an endpoint the library serves at /saml2/acs. That will process the response and fire an event when ready. The next step for you is to handle that event. You just need to login the user or refuse.
+Since Laravel 5.3, you can change your unauthenticated method in ```app/Exceptions/Handler.php```.
+```php
+protected function unauthenticated($request, AuthenticationException $exception)
+{
+	if ($request->expectsJson())
+        {
+            return response()->json(['error' => 'Unauthenticated.'], 401);
+        }
+
+        return Saml2Auth::login();
+}
+```
+
+The Saml2::login will redirect the user to the IDP and will came back to an endpoint the library serves at /myidp1/acs (or routesPrefix/myidp1/acs). That will process the response and fire an event when ready. The next step for you is to handle that event. You just need to login the user or refuse.
 
 ```php
 
  Event::listen('Aacotroneo\Saml2\Events\Saml2LoginEvent', function (Saml2LoginEvent $event) {
+            $messageId = $event->getSaml2Auth()->getLastMessageId();
+            // Add your own code preventing reuse of a $messageId to stop replay attacks
 
             $user = $event->getSaml2User();
             $userData = [
@@ -102,12 +147,44 @@ The Saml2::login will redirect the user to the IDP and will came back to an endp
         });
 
 ```
+### Auth persistence
+
+Becarefull about necessary Laravel middleware for Auth persistence in Session.
+
+For exemple, it can be:
+
+```
+# in App\Http\Kernel
+protected $middlewareGroups = [
+        'web' => [
+	    ...
+	],
+	'api' => [
+            ...
+        ],
+        'saml' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+        ],
+
+```
+
+And in `config/saml2_settings.php` :
+```
+    /**
+     * which middleware group to use for the saml routes
+     * Laravel 5.2 will need a group which includes StartSession
+     */
+    'routesMiddleware' => ['saml'],
+```
+
 ### Log out
 Now there are two ways the user can log out.
  + 1 - By logging out in your app: In this case you 'should' notify the IDP first so it closes global session.
- + 2 - By logging out of the global SSO Session. In this case the IDP will notify you on /saml2/slo endpoint (already provided)
+ + 2 - By logging out of the global SSO Session. In this case the IDP will notify you on /myidp1/slo endpoint (already provided), if the IDP supports SLO
 
-For case 1 call `Saml2Auth::logout();` or redirect the user to the route 'saml_logout' which does just that. Do not close the session inmediately as you need to receive a response confirmation from the IDP (redirection). That response will be handled by the library at /saml2/sls and will fire an event for you to complete the operation.
+For case 1 call `Saml2Auth::logout();` or redirect the user to the logout route, e.g. 'myidp1_logout' which does just that. Do not close the session immediately as you need to receive a response confirmation from the IDP (redirection). That response will be handled by the library at /myidp1/sls and will fire an event for you to complete the operation.
 
 For case 2 you will only receive the event. Both cases 1 and 2 receive the same event. 
 

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "keywords": ["laravel","saml", "saml2", "onelogin"],
     "homepage": "https://github.com/nirajp/laravel-saml2",
     "license": "MIT",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "aacotroneo",
@@ -16,8 +17,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
+        "ext-openssl": "*",
         "illuminate/support": ">=5.0.0",
-        "onelogin/php-saml": "2.9.1"
+        "onelogin/php-saml": "^3.0.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",
@@ -26,6 +28,16 @@
     "autoload": {
         "psr-0": {
             "Aacotroneo\\Saml2\\": "src/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Aacotroneo\\Saml2\\Saml2ServiceProvider"
+            ],
+            "aliases": {
+                "Saml2": "Aacotroneo\\Saml2\\Facades\\Saml2Auth"
+            }
         }
     },
     "minimum-stability": "stable"

--- a/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
+++ b/src/Aacotroneo/Saml2/Events/Saml2LoginEvent.php
@@ -2,14 +2,19 @@
 
 namespace Aacotroneo\Saml2\Events;
 
+use Aacotroneo\Saml2\Saml2User;
+use Aacotroneo\Saml2\Saml2Auth;
+
 class Saml2LoginEvent extends Saml2Event {
 
     protected $user;
+    protected $auth;
 
-    function __construct($idp, $user)
+    function __construct($idp, Saml2User $user, Saml2Auth $auth)
     {
         parent::__construct($idp);
         $this->user = $user;
+        $this->auth = $auth;
     }
 
     public function getSaml2User()
@@ -17,4 +22,8 @@ class Saml2LoginEvent extends Saml2Event {
         return $this->user;
     }
 
+    public function getSaml2Auth()
+    {
+        return $this->auth;
+    }
 }

--- a/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
+++ b/src/Aacotroneo/Saml2/Http/Controllers/Saml2Controller.php
@@ -6,7 +6,7 @@ use Aacotroneo\Saml2\Events\Saml2LoginEvent;
 use Aacotroneo\Saml2\Saml2Auth;
 use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 use URL;
 
 class Saml2Controller extends Controller
@@ -21,18 +21,34 @@ class Saml2Controller extends Controller
      */
     function __construct(Request $request){
 
-        $this->idp = explode('/',$request->path())[0];
+        // IdP name is *2nd-to-last* item in path, whether no routesPrefix ("idpName/page") or using routesPrefix ("routesPrefix/idpName/page")
+        $pathSegments = $request->segments();
+        $this->idp = $pathSegments[count($pathSegments)-2];
         if (!$this->idp) {
             $this->idp = 'test';
         }
 
         $config = config('saml2.'.$this->idp.'_idp_settings');
 
-        $config['sp']['entityId'] = URL::route($this->idp.'_metadata');
-
-        $config['sp']['assertionConsumerService']['url'] = URL::route($this->idp.'_acs');
-
-        $config['sp']['singleLogoutService']['url'] = URL::route($this->idp.'_sls');
+        if (empty($config['sp']['entityId'])) {
+            $config['sp']['entityId'] = URL::route($this->idp.'_metadata');
+        }
+        if (empty($config['sp']['assertionConsumerService']['url'])) {
+            $config['sp']['assertionConsumerService']['url'] = URL::route($this->idp.'_acs');
+        }
+        if (!empty($config['sp']['singleLogoutService']) &&
+            empty($config['sp']['singleLogoutService']['url'])) {
+            $config['sp']['singleLogoutService']['url'] = URL::route($this->idp.'_sls');
+        }
+        if (strpos($config['sp']['privateKey'], 'file://')===0) {
+            $config['sp']['privateKey'] = $this->extractPkeyFromFile($config['sp']['privateKey']);
+        }
+        if (strpos($config['sp']['x509cert'], 'file://')===0) {
+            $config['sp']['x509cert'] = $this->extractCertFromFile($config['sp']['x509cert']);
+        }
+        if (strpos($config['idp']['x509cert'], 'file://')===0) {
+            $config['idp']['x509cert'] = $this->extractCertFromFile($config['idp']['x509cert']);
+        }
 
         $auth = new OneLogin_Saml2_Auth($config);
 
@@ -53,20 +69,23 @@ class Saml2Controller extends Controller
 
     /**
      * Process an incoming saml2 assertion request.
-     * Fires 'saml2.loginRequestReceived' event if a valid user is Found
+     * Fires 'Saml2LoginEvent' event if a valid user is Found
      */
     public function acs()
     {
         $errors = $this->saml2Auth->acs();
 
         if (!empty($errors)) {
+            logger()->error('Saml2 error_detail', ['error' => $this->saml2Auth->getLastErrorReason()]);
+            session()->flash('saml2_error_detail', [$this->saml2Auth->getLastErrorReason()]);
+
             logger()->error('Saml2 error', $errors);
             session()->flash('saml2_error', $errors);
             return redirect(config('saml2_settings.errorRoute'));
         }
         $user = $this->saml2Auth->getSaml2User();
 
-        event(new Saml2LoginEvent($this->idp, $user));
+        event(new Saml2LoginEvent($this->idp, $user, $this->saml2Auth));
 
         $redirectUrl = $user->getIntendedUrl();
 
@@ -80,7 +99,7 @@ class Saml2Controller extends Controller
 
     /**
      * Process an incoming saml2 logout request.
-     * Fires 'saml2.logoutRequestReceived' event if its valid.
+     * Fires 'Saml2LogoutEvent' event if its valid.
      * This means the user logged out of the SSO infrastructure, you 'should' log him out locally too.
      */
     public function sls()
@@ -116,4 +135,30 @@ class Saml2Controller extends Controller
         $this->saml2Auth->login(config('saml2_settings.loginRoute'));
     }
 
+    protected function extractPkeyFromFile($path) {
+        $res = openssl_get_privatekey($path);
+        if (empty($res)) {
+            throw new \Exception('Could not read private key-file at path \'' . $path . '\'');
+        }
+        openssl_pkey_export($res, $pkey);
+        openssl_pkey_free($res);
+        return $this->extractOpensslString($pkey, 'PRIVATE KEY');
+    }
+
+    protected function extractCertFromFile($path) {
+        $res = openssl_x509_read(file_get_contents($path));
+        if (empty($res)) {
+            throw new \Exception('Could not read X509 certificate-file at path \'' . $path . '\'');
+        }
+        openssl_x509_export($res, $cert);
+        openssl_x509_free($res);
+        return $this->extractOpensslString($cert, 'CERTIFICATE');
+    }
+
+    protected function extractOpensslString($keyString, $delimiter) {
+        $keyString = str_replace(["\r", "\n"], "", $keyString);
+        $regex = '/-{5}BEGIN(?:\s|\w)+' . $delimiter . '-{5}\s*(.+?)\s*-{5}END(?:\s|\w)+' . $delimiter . '-{5}/m';
+        preg_match($regex, $keyString, $matches);
+        return empty($matches[1]) ? '' : $matches[1];
+    }
 }

--- a/src/Aacotroneo/Saml2/Saml2Auth.php
+++ b/src/Aacotroneo/Saml2/Saml2Auth.php
@@ -2,9 +2,9 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
-use OneLogin_Saml2_Error;
-use OneLogin_Saml2_Utils;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Error as OneLogin_Saml2_Error;
+use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use Aacotroneo\Saml2\Events\Saml2LogoutEvent;
 
 use Log;
@@ -45,25 +45,54 @@ class Saml2Auth
     }
 
     /**
+     * The ID of the last message processed
+     * @return String
+     */
+    function getLastMessageId()
+    {
+        return $this->auth->getLastMessageId();
+    }
+
+    /**
      * Initiate a saml2 login flow. It will redirect! Before calling this, check if user is
      * authenticated (here in saml2). That would be true when the assertion was received this request.
+     *
+     * @param string|null $returnTo        The target URL the user should be returned to after login.
+     * @param array       $parameters      Extra parameters to be added to the GET
+     * @param bool        $forceAuthn      When true the AuthNReuqest will set the ForceAuthn='true'
+     * @param bool        $isPassive       When true the AuthNReuqest will set the Ispassive='true'
+     * @param bool        $stay            True if we want to stay (returns the url string) False to redirect
+     * @param bool        $setNameIdPolicy When true the AuthNReuqest will set a nameIdPolicy element
+     *
+     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
      */
-    function login($returnTo = null)
+    function login($returnTo = null, $parameters = array(), $forceAuthn = false, $isPassive = false, $stay = false, $setNameIdPolicy = true)
     {
         $auth = $this->auth;
 
-        $auth->login($returnTo);
+        return $auth->login($returnTo, $parameters, $forceAuthn, $isPassive, $stay, $setNameIdPolicy);
     }
 
     /**
      * Initiate a saml2 logout flow. It will close session on all other SSO services. You should close
      * local session if applicable.
+     *
+     * @param string|null $returnTo            The target URL the user should be returned to after logout.
+     * @param string|null $nameId              The NameID that will be set in the LogoutRequest.
+     * @param string|null $sessionIndex        The SessionIndex (taken from the SAML Response in the SSO process).
+     * @param string|null $nameIdFormat        The NameID Format will be set in the LogoutRequest.
+     * @param bool        $stay            True if we want to stay (returns the url string) False to redirect
+     * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
+     *
+     * @return string|null If $stay is True, it return a string with the SLO URL + LogoutRequest + parameters
+     *
+     * @throws OneLogin_Saml2_Error
      */
-    function logout($returnTo = null, $nameId = null, $sessionIndex = null)
+    function logout($returnTo = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null, $stay = false, $nameIdNameQualifier = null)
     {
         $auth = $this->auth;
 
-        $auth->logout($returnTo, [], $nameId, $sessionIndex);
+        return $auth->logout($returnTo, [], $nameId, $sessionIndex, $stay, $nameIdFormat, $nameIdNameQualifier);
     }
 
     /**
@@ -142,5 +171,12 @@ class Saml2Auth
         }
     }
 
-
+    /**
+     * Get the last error reason from \OneLogin_Saml2_Auth, useful for error debugging.
+     * @see \OneLogin_Saml2_Auth::getLastErrorReason()
+     * @return string
+     */
+    function getLastErrorReason() {
+        return $this->auth->getLastErrorReason();
+    }
 }

--- a/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
+++ b/src/Aacotroneo/Saml2/Saml2ServiceProvider.php
@@ -1,7 +1,8 @@
 <?php
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Utils as OneLogin_Saml2_Utils;
 use URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -30,6 +31,10 @@ class Saml2ServiceProvider extends ServiceProvider
             __DIR__.'/../../config/saml2_settings.php' => config_path('saml2_settings.php'),
             __DIR__.'/../../config/test_idp_settings.php' => config_path('saml.test_idp_settings.php'),
         ]);
+
+        if (config('saml2_settings.proxyVars', false)) {
+            OneLogin_Saml2_Utils::setProxyVars(true);
+        }
     }
 
     /**

--- a/src/Aacotroneo/Saml2/Saml2User.php
+++ b/src/Aacotroneo/Saml2/Saml2User.php
@@ -2,7 +2,7 @@
 
 namespace Aacotroneo\Saml2;
 
-use OneLogin_Saml2_Auth;
+use OneLogin\Saml2\Auth as OneLogin_Saml2_Auth;
 
 /**
  * A simple class that represents the user that 'came' inside the saml2 assertion
@@ -41,6 +41,28 @@ class Saml2User
     }
 
     /**
+     * Returns the requested SAML attribute
+     *
+     * @param string $name The requested attribute of the user.
+     * @return array|null Requested SAML attribute ($name).
+     */
+    function getAttribute($name) {
+        $auth = $this->auth;
+
+        return $auth->getAttribute($name);
+    }
+    
+    /**
+     * @return array attributes retrieved from assertion processed this request
+     */
+    function getAttributesWithFriendlyName()
+    {
+        $auth = $this->auth;
+
+        return $auth->getAttributesWithFriendlyName();
+    }
+
+    /**
      * @return string the saml assertion processed this request
      */
     function getRawSamlAssertion()
@@ -57,6 +79,35 @@ class Saml2User
         if ($relayState && $url->full() != $relayState) {
 
             return $relayState;
+        }
+    }
+
+    /**
+     * Parses a SAML property and adds this property to this user or returns the value
+     *
+     * @param string $samlAttribute
+     * @param string $propertyName
+     * @return array|null
+     */
+    function parseUserAttribute($samlAttribute = null, $propertyName = null) {
+        if(empty($samlAttribute)) {
+            return null;
+        }
+        if(empty($propertyName)) {
+            return $this->getAttribute($samlAttribute);
+        }
+
+        return $this->{$propertyName} = $this->getAttribute($samlAttribute);
+    }
+
+    /**
+     * Parse the saml attributes and adds it to this user
+     *
+     * @param array $attributes Array of properties which need to be parsed, like this ['email' => 'urn:oid:0.9.2342.19200300.100.1.3']
+     */
+    function parseAttributes($attributes = array()) {
+        foreach($attributes as $propertyName => $samlAttribute) {
+            $this->parseUserAttribute($samlAttribute, $propertyName);
         }
     }
 

--- a/src/config/saml2_settings.php
+++ b/src/config/saml2_settings.php
@@ -6,13 +6,26 @@ return $settings = array(
      * Array of IDP prefixes to be configured e.g. 'idpNames' => ['test1', 'test2', 'test3'],
      * Separate routes will be automatically registered for each IDP specified with IDP name as prefix
      * Separate config file saml2/<idpName>_idp_settings.php should be added & configured accordingly
-     **/
+     */
     'idpNames' => ['test'],
 
     /**
-     * Cosmetic settings - controller routes
-     **/
-    'useRoutes' => true, //include library routes and controllers
+     * If 'useRoutes' is set to true, the package defines five new routes for reach entry in idpNames:
+     *
+     *    Method | URI                                | Name
+     *    -------|------------------------------------|------------------
+     *    POST   | {routesPrefix}/{idpName}/acs       | saml_acs
+     *    GET    | {routesPrefix}/{idpName}/login     | saml_login
+     *    GET    | {routesPrefix}/{idpName}/logout    | saml_logout
+     *    GET    | {routesPrefix}/{idpName}/metadata  | saml_metadata
+     *    GET    | {routesPrefix}/{idpName}/sls       | saml_sls
+     */
+    'useRoutes' => true,
+
+    /**
+     * Optional, leave empty if you want the defined routes to be top level, i.e. "/{idpName}/*"
+     */
+    'routesPrefix' => '/saml2',
 
     /**
      * which middleware group to use for the saml routes
@@ -36,10 +49,15 @@ return $settings = array(
      */
     'loginRoute' => '/',
 
-
     /**
      * Where to redirect after login if no other option was provided
      */
     'errorRoute' => '/',
+
+    // If 'proxyVars' is True, then the Saml lib will trust proxy headers
+    // e.g X-Forwarded-Proto / HTTP_X_FORWARDED_PROTO. This is useful if
+    // your application is running behind a load balancer which terminates
+    // SSL.
+    'proxyVars' => false,
 
 );

--- a/src/routes.php
+++ b/src/routes.php
@@ -3,7 +3,7 @@
 foreach (config('saml2_settings.idpNames') as $key => $value) {
    
     Route::group([
-        'prefix' => $value,
+        'prefix' => config('saml2_settings.routesPrefix').'/'.$value,
         'middleware' => config('saml2_settings.routesMiddleware'),
     ], function () use ($value) {
         

--- a/tests/Saml2/Saml2AuthServiceProviderTest.php
+++ b/tests/Saml2/Saml2AuthServiceProviderTest.php
@@ -5,8 +5,9 @@ namespace Aacotroneo\Saml2;
 
 use App;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class Saml2AuthServiceProviderTest extends \PHPUnit_Framework_TestCase
+class Saml2AuthServiceProviderTest extends TestCase
 {
 
 

--- a/tests/Saml2/Saml2AuthTest.php
+++ b/tests/Saml2/Saml2AuthTest.php
@@ -5,8 +5,9 @@ namespace Aacotroneo\Saml2;
 
 use App;
 use Mockery as m;
+use PHPUnit\Framework\TestCase;
 
-class Saml2AuthTest extends \PHPUnit_Framework_TestCase
+class Saml2AuthTest extends TestCase
 {
 
 
@@ -18,7 +19,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testIsAuthenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
 
         $auth->shouldReceive('isAuthenticated')->andReturn('return');
@@ -29,7 +30,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testLogin()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('login')->once();
         $saml2->login();
@@ -40,18 +41,21 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $expectedReturnTo = 'http://localhost';
         $expectedSessionIndex = 'session_index_value';
         $expectedNameId = 'name_id_value';
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $expectedNameIdFormat = 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified';
+        $expectedStay = true;
+        $expectedNameIdNameQualifier = 'name_id_name_qualifier';
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('logout')
-            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex)
+            ->with($expectedReturnTo, [], $expectedNameId, $expectedSessionIndex, $expectedStay, $expectedNameIdFormat, $expectedNameIdNameQualifier)
             ->once();
-        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex);
+        $saml2->logout($expectedReturnTo, $expectedNameId, $expectedSessionIndex, $expectedNameIdFormat, $expectedStay, $expectedNameIdNameQualifier);
     }
 
 
     public function testAcsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(array('errors'));
@@ -65,7 +69,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testAcsNotAutenticated()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -79,7 +83,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testAcsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processResponse')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -92,7 +96,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testSlsError()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn('errors');
@@ -105,7 +109,7 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
 
     public function testSlsOK()
     {
-        $auth = m::mock('OneLogin_Saml2_Auth');
+        $auth = m::mock('OneLogin\Saml2\Auth');
         $saml2 = new Saml2Auth($auth);
         $auth->shouldReceive('processSLO')->once();
         $auth->shouldReceive('getErrors')->once()->andReturn(null);
@@ -113,6 +117,63 @@ class Saml2AuthTest extends \PHPUnit_Framework_TestCase
         $error =  $saml2->sls('test');
 
         $this->assertEmpty($error);
+    }
+
+    public function testCanGetLastError()
+    {
+        $auth = m::mock('OneLogin\Saml2\Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $auth->shouldReceive('getLastErrorReason')->andReturn('lastError');
+
+        $this->assertSame('lastError', $saml2->getLastErrorReason());
+    }
+
+    public function testGetUserAttribute() {
+        $auth = m::mock('OneLogin\Saml2\Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->with('urn:oid:0.9.2342.19200300.100.1.3')
+            ->andReturn(['test@example.com']);
+
+        $this->assertEquals(['test@example.com'], $user->getAttribute('urn:oid:0.9.2342.19200300.100.1.3'));
+    }
+
+    public function testParseSingleUserAttribute() {
+        $auth = m::mock('OneLogin\Saml2\Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->with('urn:oid:0.9.2342.19200300.100.1.3')
+            ->andReturn(['test@example.com']);
+
+        $user->parseUserAttribute('urn:oid:0.9.2342.19200300.100.1.3', 'email');
+
+        $this->assertEquals($user->email, ['test@example.com']);
+    }
+
+    public function testParseMultipleUserAttributes() {
+        $auth = m::mock('OneLogin\Saml2\Auth');
+        $saml2 = new Saml2Auth($auth);
+
+        $user = $saml2->getSaml2User();
+
+        $auth->shouldReceive('getAttribute')
+            ->twice()
+            ->andReturn(['test@example.com'], ['Test User']);
+
+        $user->parseAttributes([
+            'email' => 'urn:oid:0.9.2342.19200300.100.1.3',
+            'displayName' => 'urn:oid:2.16.840.1.113730.3.1.241'
+        ]);
+
+        $this->assertEquals($user->email, ['test@example.com']);
+        $this->assertEquals($user->displayName, ['Test User']);
     }
 
 /**


### PR DESCRIPTION
The nirajp/laravel-saml2 fork is very useful, because it added support
for multiple IdPs, but in the almost 3 years that have passed,
mcrypt used by onelogin v2 has been deprecated/removed in PHP 7.1/7.2.
The upstream project updated to use onelogin v3, but this fork
did not get those changes.

This commit syncs with the latest
[aacotroneo/laravel-saml2](https://github.com/aacotroneo/laravel-saml2).
This merge brings in the onelogin v3 update, as well as the rest of
the improvements on the upstream repo.

Merge notes:
- Upstream changes were made in `register()` where the onelogin config
is prepared; in this commit those changes are moved to the
Saml2Controller constructor, which is where this fork moved onelogin
instantiation.
- Brings proxyVars setting into saml2_config.php
- Adds the new (optional) routesPrefix saml2_config.php setting. Changes
to routes.php to use it as an (optional) prefix to all the idp-specific
generated routes, and to Saml2Controller constructor's parsing of the path.
- Upstream added optional ENV vars for IdP and SP config. This commit
makes the same possible on a per-IdP basis, by providing a pattern for
the IdP configs to specify IdP-specific SAML2_* ENV var naming.
- Update README.md to reflect the new configuration options from upstream,
in the context of this fork's support for multiple IdPs.
- Bump version number. (Upstream is now 1.0.0, so I chose that too)